### PR TITLE
Remove radius from inRange calculation

### DIFF
--- a/systems/ai/Prerequisites.lua
+++ b/systems/ai/Prerequisites.lua
@@ -8,7 +8,6 @@ function Prerequisites.InAttackRange(action, prerequisite, agent, target, dt)
     local targetPosition = target:get("Position")
 
     local distance = (agentPosition:toVector() - targetPosition:toVector()):len()
-    local distance = distance - agent:get("Circle").radius - target:get("Circle").radius
     if(distance < 0) then
       distance = 0
     end


### PR DESCRIPTION
#### Quick hotfix
Enemy bullet is spawned inside him so the inrange prerequisite should not consider the enemy radius 

Another options is spawn the bullet "outside" the enemy - same as player